### PR TITLE
Build moses project with cython error

### DIFF
--- a/.github/workflows/ci-org-v7a.yml
+++ b/.github/workflows/ci-org-v7a.yml
@@ -146,6 +146,10 @@ jobs:
           cd ../../..
 
       # 7. Build and Install MoSES
+      - name: Install Python build deps for MoSES
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev cython3 python3-nose
       - name: Build and Install MoSES
         run: |
           # Use local repository from monorepo

--- a/.github/workflows/ocg.yml
+++ b/.github/workflows/ocg.yml
@@ -248,6 +248,10 @@ jobs:
           cd ../../..
 
       # 14. Build and Install moses
+      - name: Install Python build deps for MOSES
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev cython3 python3-nose
       - name: Build and Install moses
         run: |
           cd repos/moses


### PR DESCRIPTION
Install Python development dependencies in CI workflows to fix `Python.h` and Cython-related build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ebaba04-0af1-4100-8a87-1c6ed053cf41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ebaba04-0af1-4100-8a87-1c6ed053cf41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

